### PR TITLE
Support for multiline regex and declaring safe types in SqlStringConcatentation

### DIFF
--- a/rulesets/GDS/OWASP/A1 - Injection.xml
+++ b/rulesets/GDS/OWASP/A1 - Injection.xml
@@ -1,53 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="A1 - Injection" language="java"
-	xmlns="http://pmd.sf.net/ruleset/1.0.0" 
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-	xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd" 
-	xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd">
+   xmlns="http://pmd.sf.net/ruleset/1.0.0" 
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+   xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd" 
+   xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd">
    
    <description>
-   		This file is part of the GDS PMD Secure Coding Ruleset.
-   		   		
-   		This ruleset contains rules that are intended to detect Injection flaws (SQLi, XMLi, LDAPi, etc).
+         This file is part of the GDS PMD Secure Coding Ruleset.
+                  
+         This ruleset contains rules that are intended to detect Injection flaws (SQLi, XMLi, LDAPi, etc).
    </description>
 
-	<rule class="com.gdssecurity.pmd.rules.dfa.DfaSecurityRule" name="SqlInjectionDfa" message="Sql Injection" dfa="true" typeResolution="true" externalInfoUrl="http://www.owasp.org/index.php/Top_10_2010-A2">
+   <rule class="com.gdssecurity.pmd.rules.dfa.DfaSecurityRule" name="SqlInjectionDfa" message="Sql Injection" dfa="true" typeResolution="true" externalInfoUrl="http://www.owasp.org/index.php/Top_10_2010-A2">
       <description>
-	This rule utilizes the PMD data flow analysis (DFA) layer to help trace input from source to sink. PMD is unable to track data flow from source to sink across files. Therefore, the scope of analysis is limited to a single file and even within that a single method (i.e. PMD DFA is intraprocedural).
-	
-	Specifically, it is configured with sinks that might suggest a potential SQL Injection vulnerability. Additional sinks should be added for increased coverage.	
+   This rule utilizes the PMD data flow analysis (DFA) layer to help trace input from source to sink. PMD is unable to track data flow from source to sink across files. Therefore, the scope of analysis is limited to a single file and even within that a single method (i.e. PMD DFA is intraprocedural).
+   
+   Specifically, it is configured with sinks that might suggest a potential SQL Injection vulnerability. Additional sinks should be added for increased coverage. 
       </description>
       
       <priority>1</priority>
       
       <properties>         
          <property name="sinks">
-         	<value>java.sql.Statement.executeQuery|</value>
+            <value>java.sql.Statement.executeQuery|</value>
          </property>
       </properties>
   
    </rule>
   
    <rule class="com.gdssecurity.pmd.rules.SqlStringConcatentation" message="{0} of type {1} concatenated to SQL string creating a possible SQL Injection vulnerability. Additional information: {2}." name="SqlStringConcatentation" externalInfoUrl="http://www.owasp.org/index.php/Top_10_2010-A1">
-      <description>     	
-     	This rule identifies expressions that appear to be SQL statements concatenated with objects of type java.lang.String or potentially other dangerous types that could potentially expose the application to SQL Injection. When evaluating the violation, the concatenated expression(s) must be manually reviewed for user-controllable input. If the type is likely to contain/return tainted data (such as javax.servlet.http.HttpServletRequest) these can be configured via the insecureTypes property.
+      <description>        
+      This rule identifies expressions that appear to be SQL statements concatenated with objects of type java.lang.String or potentially other dangerous types that could potentially expose the application to SQL Injection. When evaluating the violation, the concatenated expression(s) must be manually reviewed for user-controllable input. If the type is likely to contain/return tainted data (such as javax.servlet.http.HttpServletRequest) these can be configured via the insecureTypes property.
 
-	Concatenation is identified by inspecting the AST for AdditiveExpression nodes. The pattern used to identify SQL statements is configured with the standardsqlregex and customsqlregex properties. The customsqlregex property allows for detection of custom SQL statements, such as application stored procedures and functions. 
+   Concatenation is identified by inspecting the AST for AdditiveExpression nodes. The pattern used to identify SQL statements is configured with the standardsqlregex and customsqlregex properties. The customsqlregex property allows for detection of custom SQL statements, such as application stored procedures and functions. 
 
-	This rule was implemented to help identify potential SQL Injection because PMD is unable to track data flow from source to sink across files.
+   This rule was implemented to help identify potential SQL Injection because PMD is unable to track data flow from source to sink across files.
       </description>
       
       <priority>3</priority>
-      
+      <!-- The Regex values are Case Insensitive and will match on Multiline -->
       <properties>
         <property name="standardsqlregex">
-         	<value>select.+from.+(where)?|insert.+into|update.+set|delete.+(from|where)</value>
+            <value>select.+from.+(where)?|insert.+into|update.+set|delete.+(from|where)</value>
          </property>
          <property name="customsqlregex">
-         	<value></value>
+            <value></value>
          </property>
          <property name="insecureTypes">
-         	<value>javax.servlet.http.HttpServletRequest|</value>
+            <value>javax.servlet.http.HttpServletRequest|</value>
+         </property>
+         <!-- By default all numeric types are ignored and considered safe. Add each type seperated by "|"-->
+         <property name="safeTypes">
+            <value>java.lang.Long|java.lang.Integer|java.lang.Short|java.lang.Byte|java.lang.Double|java.lang.Float|java.math.BigInteger|java.math.BigDecimal</value>
          </property>
       </properties>
       


### PR DESCRIPTION
- Added multiline support to the regular expressions in SqlStringConcatentation
- Included support for declaring safe types that must be ignored while checking for SqlStringConcatentation. By default JAVA numeric types are ignored.
